### PR TITLE
Add Resolve to Config

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,9 @@ Elixir.ready(function() {
                     loader: 'babel'
                 }
             ]
+        },
+        resolve: {
+            extensions: ['', '.js', '.json', '.jsx' ]
         }
     });
 });


### PR DESCRIPTION
Eneable extensionless imports of jsx files by updating webpack's config
( found via -
https://webpack.js.org/configuration/resolve/#resolve-extensions )

Resolves Issue - https://github.com/tightenco/laravel-elixir-webpack-react/issues/1